### PR TITLE
[FEATURE] Add option to override appId to allow cross-domain usage

### DIFF
--- a/Classes/Provider/WebAuthnProvider.php
+++ b/Classes/Provider/WebAuthnProvider.php
@@ -26,6 +26,7 @@ use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Core\Authentication\Mfa\MfaProviderInterface;
 use TYPO3\CMS\Core\Authentication\Mfa\MfaProviderPropertyManager;
 use TYPO3\CMS\Core\Authentication\Mfa\MfaViewType;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration;
 use TYPO3\CMS\Core\Context\Context;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\Information\Typo3Version;
@@ -405,7 +406,9 @@ class WebAuthnProvider implements MfaProviderInterface, LoggerAwareInterface
         MfaProviderPropertyManager $propertyManager
     ): Server {
         $name = 'TYPO3 Backend';
-        $id = $request->getAttribute('normalizedParams')->getRequestHostOnly();
+        $extensionConfiguration = GeneralUtility::makeInstance(ExtensionConfiguration::class)
+            ->get('mfa_webauthn');
+        $id = $extensionConfiguration['appId'] ?? $request->getAttribute('normalizedParams')->getRequestHostOnly();
 
         $server = new Server(
             new PublicKeyCredentialRpEntity($name, $id),

--- a/README.md
+++ b/README.md
@@ -24,13 +24,17 @@ This puts the following limitations on usages of this provider:
 
  * Requires HTTPS or a localhost environment
    (therefore use `http://{myproject}.localhost` as local development URL)
- * Works only for one domain, multi domain sites need to have TYPO3 backend redirected to exactly
-   one domain, or should use alternative MFA MFA providers.
-
+ * WebAuthn API is bound to one domain which is used as the application ID. In general the backend for a system should
+   be available via one primary domain only. If that is not the case or if you want to share the WebAuthn tokens e.g.
+   between a production system and its copies, there is an extension configuration item which can be used to enforce a
+   specific domain instead of deriving it from the backend request:
+```
+$GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['mfa_webauthn']['appId'] = 'primarydomain.example.com`;
+```
 
 ## Alternative Extensions
 
-If the restriction to one backend domain is too limiting, consider using [mfa_yubikey](https://github.com/derhansen/mfa_yubikey)
+If this extension is too limiting, consider using [mfa_yubikey](https://github.com/derhansen/mfa_yubikey)
  or [mfa_hotp](https://github.com/o-ba/mfa_hotp) instead. Note, both providers are less secure than webauthn, as the user
 can be spoofed with a faked domain name, but they are more flexible and both allow to use hardware tokens with a multi
 domain setup.

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -1,0 +1,2 @@
+# cat=Id; type=string; label=ID: If set, this domain name will be used instead of request domain.
+appId =


### PR DESCRIPTION
Currently the WebAuthn app ID is derived from the backend request. This change allows a fixed string (domain name) for the app ID via extension configuration. This enables e.g. to re-use the WebAuthn if the system is mirrored or copied (e.g. PRODUCTION > STAGING).